### PR TITLE
feat: add concurrent install and uninstall

### DIFF
--- a/jb-lib/src/tool.rs
+++ b/jb-lib/src/tool.rs
@@ -35,7 +35,7 @@ pub use release::{Type, Version};
 ///   .with_version("2021.2.1".parse().unwrap())
 ///   .with_directory("/home/user/.local/share/JetBrains".into());
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[readonly::make]
 pub struct Tool {
     /// The kind of tool
@@ -114,6 +114,21 @@ impl Tool {
         }
 
         Ok(installed_tools)
+    }
+
+    /// List all installed `JetBrains` tools of a specific kind.
+    ///
+    /// This function is a shorthand for `Tool::list` and filters the list of installed tools by kind.
+    ///
+    /// # Errors
+    /// This function may return an error if it fails to list the installed tools.
+    pub fn list_kind(kind: Kind, directory: Option<PathBuf>) -> Result<Vec<Tool>> {
+        Ok(
+            Tool::list(directory)?
+            .into_iter()
+            .filter(|tool| tool.kind == kind)
+            .collect()
+        )
     }
 
     /// Set the version of the tool.
@@ -213,7 +228,7 @@ impl Tool {
         let tool_dir = self.as_path();
 
         if self.is_linked() {
-            tracing::debug!("{} is already linked", self.kind.as_str());
+            tracing::error!("{} is already linked", self.kind.as_str());
             bail!("{} is already linked", self.kind.as_str());
         }
 

--- a/jb-lib/src/tool/kind.rs
+++ b/jb-lib/src/tool/kind.rs
@@ -2,6 +2,7 @@
 //!
 //! The tool kind represents the tool among the `JetBrains` products.
 
+use std::str::FromStr;
 use super::release::Type;
 use clap::builder::PossibleValue;
 
@@ -199,5 +200,37 @@ impl clap::ValueEnum for Kind {
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
         Some(PossibleValue::new(self.as_str()))
+    }
+}
+
+impl FromStr for Kind {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "idea-ultimate" => Ok(Self::IntelliJIdeaUltimate),
+            "idea-community" => Ok(Self::IntelliJIdeaCommunity),
+            "pycharm-professional" => Ok(Self::PyCharmProfessional),
+            "pycharm-community" => Ok(Self::PyCharmCommunity),
+            "phpstorm" => Ok(Self::PhpStorm),
+            "goland" => Ok(Self::GoLand),
+            "rider" => Ok(Self::Rider),
+            "clion" => Ok(Self::CLion),
+            "clion-nova" => Ok(Self::ClionNova),
+            "rustrover" => Ok(Self::RustRover),
+            "webstorm" => Ok(Self::WebStorm),
+            "rubymine" => Ok(Self::RubyMine),
+            "datagrip" => Ok(Self::DataGrip),
+            "dataspell" => Ok(Self::DataSpell),
+            "fleet" => Ok(Self::Fleet),
+            "aqua" => Ok(Self::Aqua),
+            "writerside" => Ok(Self::Writerside),
+            "dotmemory" => Ok(Self::DotMemory),
+            "dottrace" => Ok(Self::DotTrace),
+            "mps" => Ok(Self::MPS),
+            "space" => Ok(Self::Space),
+            "gateway" => Ok(Self::Gateway),
+            _ => anyhow::bail!("Unknown tool kind: {}", s)
+        }
     }
 }

--- a/jb-lib/src/tool/kind.rs
+++ b/jb-lib/src/tool/kind.rs
@@ -2,14 +2,16 @@
 //!
 //! The tool kind represents the tool among the `JetBrains` products.
 
+use std::cmp::Ordering;
 use std::str::FromStr;
+
 use super::release::Type;
 use clap::builder::PossibleValue;
 
 /// Tool kind
 ///
 /// This enum does not contain any information. It only represents which kind of tool it is.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Kind {
     IntelliJIdeaUltimate,
     IntelliJIdeaCommunity,
@@ -232,5 +234,17 @@ impl FromStr for Kind {
             "gateway" => Ok(Self::Gateway),
             _ => anyhow::bail!("Unknown tool kind: {}", s)
         }
+    }
+}
+
+impl Ord for Kind {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialOrd for Kind {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }

--- a/jb-lib/src/tool/release.rs
+++ b/jb-lib/src/tool/release.rs
@@ -168,6 +168,14 @@ impl Version {
         self.major.is_none() && self.minor.is_none() && self.patch.is_none()
     }
 
+    /// Check if this version is complete
+    ///
+    /// This returns `true` if the version has all three version numbers set, and `false` otherwise.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.major.is_some() && self.minor.is_some() && self.patch.is_some()
+    }
+
     /// Compare this version to another version, ignoring the release type
     ///
     /// This returns an `Ordering` representing the comparison between the two versions.

--- a/jb-lib/src/tool/release.rs
+++ b/jb-lib/src/tool/release.rs
@@ -1,6 +1,6 @@
 //! Release version parsing and comparison
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::builder::PossibleValue;
 use serde::Deserialize;
 use std::cmp::Ordering;
@@ -277,12 +277,13 @@ impl std::fmt::Display for Version {
 }
 
 impl FromStr for Version {
-    type Err = &'static str;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut base = s.split('-');
 
-        let first = base.next().ok_or("Failed to parse version")?;
+        let first = base.next()
+            .with_context(|| "Failed to parse version: no version numbers")?;
 
         // Check if it's a release type
         if let Ok(release) = Type::from_str(first) {
@@ -297,17 +298,17 @@ impl FromStr for Version {
                 }
 
                 part.parse::<u32>()
-                    .map_err(|_| "Failed to parse version number")
+                    .with_context(|| format!("Failed to parse version: invalid version number: {part}"))
                     .map(Some)
             })
             .collect::<Result<Vec<_>, _>>()?;
 
         if parts.len() > 3 {
-            return Err("Failed to parse version: too many version numbers");
+            anyhow::bail!("Failed to parse version: too many version numbers");
         }
 
         if parts.first().is_none() {
-            return Err("Failed to parse version: major version is required if no release_type is specified");
+            anyhow::bail!("Failed to parse version: no version numbers found when no release type is specified");
         }
 
         // Parse release type
@@ -317,7 +318,7 @@ impl FromStr for Version {
                 "release" => Ok(Type::Release),
                 "eap" => Ok(Type::EAP),
                 "preview" => Ok(Type::Preview),
-                _ => Err("Failed to parse release type"),
+                _ => anyhow::bail!("Failed to parse version: invalid release type")
             })
             .transpose()?;
 

--- a/jb/src/cmds/install.rs
+++ b/jb/src/cmds/install.rs
@@ -7,9 +7,9 @@ use jb_lib::{tool::Tool, error::{Result, Batch}};
 
 pub(crate) fn command() -> Command {
     Command::new("install")
-        .about("Install a JetBrains tool")
+        .about("Install JetBrains tools")
         .arg(
-            arg!(tool: <TOOL> "The tools to install")
+            arg!(tools: <TOOLS> "The tools to install")
                 .required(true)
                 .value_parser(value_parser!(Tool))
                 .num_args(1..=10),
@@ -29,7 +29,7 @@ pub(crate) fn command() -> Command {
 
 pub(crate) fn dispatch(args: &clap::ArgMatches) -> Result<()> {
     let tools = args
-        .get_many::<Tool>("tool")
+        .get_many::<Tool>("tools")
         .expect("Could not find argument tools");
     let directory: Option<&std::path::PathBuf> = args.get_one::<std::path::PathBuf>("directory");
 

--- a/jb/src/cmds/install.rs
+++ b/jb/src/cmds/install.rs
@@ -3,7 +3,7 @@ use std::thread;
 use anyhow::anyhow;
 
 use clap::{arg, value_parser, Command};
-use jb_lib::{tool::{Kind, Tool, Version}, error::{Result, Batch}};
+use jb_lib::{tool::Tool, error::{Result, Batch}};
 
 pub(crate) fn command() -> Command {
     Command::new("install")
@@ -11,14 +11,8 @@ pub(crate) fn command() -> Command {
         .arg(
             arg!(tool: <TOOL> "The tools to install")
                 .required(true)
-                .value_parser(value_parser!(Kind))
+                .value_parser(value_parser!(Tool))
                 .num_args(1..=10),
-        )
-        .arg(
-            arg!(--build <VERSION>)
-                .help("The release version to install (e.g. '2023.2.1-eap' or 'preview')")
-                .value_parser(value_parser!(Version))
-                .required(false),
         )
         .arg(
             arg!(-d --directory <PATH>)
@@ -34,20 +28,16 @@ pub(crate) fn command() -> Command {
 }
 
 pub(crate) fn dispatch(args: &clap::ArgMatches) -> Result<()> {
-    let tool_kinds = args
-        .get_many::<Kind>("tool")
+    let tools = args
+        .get_many::<Tool>("tool")
         .expect("Could not find argument tools");
-    let version: Option<&Version> = args.get_one::<Version>("build");
     let directory: Option<&std::path::PathBuf> = args.get_one::<std::path::PathBuf>("directory");
 
     let clean = Arc::new(args.get_flag("clean"));
 
-    let handles: Vec<_> = tool_kinds
-        .map(|tool_kind| {
-            let mut tool = Tool::new(*tool_kind);
-            if version.is_some() {
-                tool = tool.with_version(*version.unwrap());
-            }
+    let handles: Vec<_> = tools
+        .map(|tool| {
+            let mut tool = tool.clone();
             if directory.is_some() {
                 tool = tool.with_directory(directory.unwrap().clone());
             }
@@ -55,7 +45,7 @@ pub(crate) fn dispatch(args: &clap::ArgMatches) -> Result<()> {
             let clean = Arc::clone(&clean);
 
             thread::spawn(move || {
-                let span = tracing::info_span!("task", tool = tool.name());
+                let span = tracing::info_span!("task", tool = tool.to_string());
                 let _guard = span.enter();
 
                 tool.install()?;
@@ -64,7 +54,7 @@ pub(crate) fn dispatch(args: &clap::ArgMatches) -> Result<()> {
 
                 if *clean {
                     // Clean up old versions
-                    let span = tracing::info_span!("cleanup", tool = tool.name());
+                    let span = tracing::info_span!("cleanup", tool = tool.to_string());
                     let _guard = span.enter();
 
                     tracing::info!("Cleaning up old versions of {}", tool.kind.as_str());

--- a/jb/src/cmds/link.rs
+++ b/jb/src/cmds/link.rs
@@ -1,6 +1,5 @@
 use clap::{arg, value_parser, Command};
-use colored::Colorize;
-use jb_lib::{tool::{Kind, Tool, Version},error::{Batch,Result}};
+use jb_lib::{tool::Tool,error::{Batch,Result}};
 
 pub(crate) fn command() -> Command {
     Command::new("link")
@@ -8,13 +7,7 @@ pub(crate) fn command() -> Command {
         .arg(
             arg!(tool: <TOOL> "The tool to link")
                 .required(true)
-                .value_parser(value_parser!(Kind)),
-        )
-        .arg(
-            arg!(version: <VERSION>)
-                .help("The release version to link (e.g. '2023.2.1-eap' or 'preview')")
-                .value_parser(value_parser!(Version))
-                .required(true),
+                .value_parser(value_parser!(Tool)),
         )
         .arg(
             arg!(-d --directory <PATH>)
@@ -25,14 +18,9 @@ pub(crate) fn command() -> Command {
 }
 
 pub(crate) fn dispatch(args: &clap::ArgMatches) -> Result<()> {
-    let tool_kind = args
-        .get_one::<Kind>("tool")
+    let tool = args
+        .get_one::<Tool>("tool")
         .expect("Could not find argument tool");
-    let version = args
-        .get_one::<Version>("version")
-        .expect("Could not find argument version");
-
-    let tool = Tool::new(*tool_kind).with_version(*version);
 
     match tool.link() {
         Ok(()) => {}
@@ -43,11 +31,7 @@ pub(crate) fn dispatch(args: &clap::ArgMatches) -> Result<()> {
         }
     }
 
-    tracing::info!(
-        "Linked {} to {}",
-        tool.kind.as_str().bright_green(),
-        tool.as_path().display().to_string().bright_green()
-    );
+    tracing::info!("Linked {} to {tool}", tool.kind.as_str());
 
     Ok(())
 }

--- a/jb/src/cmds/uninstall.rs
+++ b/jb/src/cmds/uninstall.rs
@@ -75,7 +75,7 @@ pub(crate) fn dispatch(args: &clap::ArgMatches) -> Result<()> {
                         return false;
                     }
 
-                    return true;
+                    true
                 })
                 .collect::<Vec<Tool>>();
 
@@ -130,6 +130,6 @@ pub(crate) fn dispatch(args: &clap::ArgMatches) -> Result<()> {
     if error_batch.is_empty() {
         Ok(())
     } else {
-        Err(error_batch.into())
+        Err(error_batch)
     }
 }

--- a/jb/src/cmds/uninstall.rs
+++ b/jb/src/cmds/uninstall.rs
@@ -1,6 +1,6 @@
 use std::thread;
 use clap::{arg, value_parser, Command};
-use jb_lib::{tool::Tool, error::{Result, Batch}};
+use jb_lib::{tool::{Tool, release}, error::{Result, Batch}};
 
 pub(crate) fn command() -> Command {
     Command::new("uninstall")
@@ -19,44 +19,91 @@ pub(crate) fn command() -> Command {
 }
 
 pub(crate) fn dispatch(args: &clap::ArgMatches) -> Result<()> {
-    let tools = args
+    let args_tools = args
         .get_many::<Tool>("tools")
         .expect("Could not find argument tool");
     let directory = args.get_one::<std::path::PathBuf>("directory");
 
+    let mut tools: Vec<Tool> = Vec::new();
+    let installed_tools = match Tool::list(directory.cloned()) {
+        Ok(tools) => tools,
+        Err(e) => return Err(Batch::from(e)),
+    };
+
+    let mut error_batch = Batch::new();
+
+    for tool in args_tools {
+        if tool.version.is_none() {
+            let installed_tools = installed_tools.clone()
+                .into_iter()
+                .filter(|t| t.kind == tool.kind)
+                .collect::<Vec<Tool>>();
+
+            if installed_tools.is_empty() {
+                error_batch.add(anyhow::anyhow!("Could not find any installed versions of {}", tool.kind.as_str()));
+            } else {
+                tools.extend(installed_tools);
+            }
+        } else {
+            let version = tool.version.as_ref().unwrap();
+
+            if version.is_complete() {
+                tools.push(tool.clone());
+                continue;
+            }
+
+            // Match against the version
+            let installed_tools = installed_tools.clone()
+                .into_iter()
+                .filter(|t| {
+                    if t.kind != tool.kind || t.version.is_none() {
+                        return false;
+                    }
+
+                    let t = t.version.unwrap();
+
+                    if version.major.is_some() && (t.major.is_none() || t.major.unwrap() != version.major.unwrap()) {
+                        return false;
+                    }
+                    if version.minor.is_some() && (t.minor.is_none() || t.minor.unwrap() != version.minor.unwrap()) {
+                        return false;
+                    }
+                    if version.patch.is_some() && (t.patch.is_none() || t.patch.unwrap() != version.patch.unwrap()) {
+                        return false;
+                    }
+                    if version.release != release::Type::Release && (t.release != version.release) {
+                        return false;
+                    }
+
+                    return true;
+                })
+                .collect::<Vec<Tool>>();
+
+            if installed_tools.is_empty() {
+                error_batch.add(anyhow::anyhow!("Could not find any installed versions of {tool}"));
+            } else {
+                tools.extend(installed_tools);
+            }
+        }
+    }
+
+    if !error_batch.is_empty() {
+        return Err(error_batch);
+    }
+
+    tools.sort(); tools.dedup();
+
     let handles: Vec<_> = tools
+        .iter()
         .map(|tool| {
             let mut tool = tool.clone();
             if directory.is_some() {
-                tool = tool.with_directory(directory.unwrap().clone());
+                tool = tool.with_directory(directory.cloned().unwrap());
             }
 
             thread::spawn(move || {
                 let span = tracing::info_span!("task", tool = tool.to_string());
                 let _guard = span.enter();
-
-                if tool.version.is_none() {
-                    // Find the linked version
-                    let installed_tools = Tool::list(tool.directory.clone())?
-                        .into_iter()
-                        .filter(|t| t.kind == tool.kind)
-                        .collect::<Vec<Tool>>();
-
-                    if installed_tools.is_empty() {
-                        anyhow::bail!("Could not find any installed versions of {}", tool.kind.as_str());
-                    } else if installed_tools.len() == 1 {
-                        // No need to search for linked version
-                        tool = installed_tools[0].clone();
-                    } else {
-                        // Find the one that is linked
-                        let linked_tool = installed_tools.iter().find(|t| t.is_linked());
-
-                        match linked_tool {
-                            Some(t) => tool = t.clone(),
-                            None => anyhow::bail!("Could not find a linked version of {}", tool.kind.as_str()),
-                        }
-                    }
-                }
 
                 tool.uninstall()?;
 


### PR DESCRIPTION
Allow directly specifying multiple tools and versions (e.g. `jb install phpstorm-eap rider-2023.3.1 rustrover`).

Fixes #3  